### PR TITLE
Fix missing type in edit command

### DIFF
--- a/docs/install/Knative-with-Contour.md
+++ b/docs/install/Knative-with-Contour.md
@@ -63,7 +63,7 @@ data:
 
 Enter the following command to add the key:
 
-        kubectl edit --namespace knative-serving config-network
+        kubectl edit --namespace knative-serving configmap config-network
 
 
 


### PR DESCRIPTION
The command is missing the type `configmap`